### PR TITLE
Fix: Reload stylesheet on tab wake on suspend

### DIFF
--- a/internal/views/pages/base.templ
+++ b/internal/views/pages/base.templ
@@ -236,19 +236,30 @@ templ SideNavLayout(head templ.Component) {
 				})
 			</script>
 			<script>
+				function reloadStylesheetsIfNeeded() {
+					// Check if styles are missing
+					const bodyStyles = window.getComputedStyle(document.body);
+					if (!bodyStyles || bodyStyles.display === 'none' || bodyStyles.display === '') {
+					// Styles are missing, reload all stylesheets
+					const stylesheets = document.querySelectorAll('link[rel="stylesheet"]');
+					stylesheets.forEach((stylesheet) => {
+						const href = stylesheet.getAttribute('href').split('?')[0];
+						stylesheet.setAttribute('href', `${href}?reload=${Date.now()}`);
+					});
+					}
+				}
+
+				// Handle page show event
+				window.addEventListener('pageshow', function(event) {
+					if (event.persisted) {
+					reloadStylesheetsIfNeeded();
+					}
+				});
+
+				// Handle visibility change event
 				document.addEventListener('visibilitychange', function() {
 					if (document.visibilityState === 'visible') {
-						// Check if styles are missing
-						const bodyStyles = window.getComputedStyle(document.body);
-						if (!bodyStyles || bodyStyles.display === 'none' || bodyStyles.display === '') {
-							// Styles are missing, reload the stylesheet
-							const stylesheet = document.querySelector('link[rel="stylesheet"]');
-							if (stylesheet) {
-								const href = stylesheet.getAttribute('href').split('?')[0];
-								// Force reload by adding a unique query parameter
-								stylesheet.setAttribute('href', `${href}?reload=${Date.now()}`);
-							}
-						}
+					reloadStylesheetsIfNeeded();
 					}
 				});
 			</script>

--- a/internal/views/pages/base.templ
+++ b/internal/views/pages/base.templ
@@ -236,18 +236,20 @@ templ SideNavLayout(head templ.Component) {
 				})
 			</script>
 			<script>
-				document.addEventListener('htmx:afterSettle', function() {
-				// Check if styles are already applied
-				const bodyStyles = window.getComputedStyle(document.body);
-				if (bodyStyles.display === 'block') {
-					// Styles are already applied, no need to reload
-					return;
-				}
-				// Force a reload of the stylesheet only if styles are missing
-				const stylesheet = document.querySelector('link[rel="stylesheet"]');
-				if (stylesheet) {
-					stylesheet.href = stylesheet.href + '?reload=' + Date.now();
-				}
+				document.addEventListener('visibilitychange', function() {
+					if (document.visibilityState === 'visible') {
+						// Check if styles are missing
+						const bodyStyles = window.getComputedStyle(document.body);
+						if (!bodyStyles || bodyStyles.display === 'none' || bodyStyles.display === '') {
+							// Styles are missing, reload the stylesheet
+							const stylesheet = document.querySelector('link[rel="stylesheet"]');
+							if (stylesheet) {
+								const href = stylesheet.getAttribute('href').split('?')[0];
+								// Force reload by adding a unique query parameter
+								stylesheet.setAttribute('href', `${href}?reload=${Date.now()}`);
+							}
+						}
+					}
 				});
 			</script>
 		</body>

--- a/internal/views/pages/base.templ
+++ b/internal/views/pages/base.templ
@@ -235,6 +235,21 @@ templ SideNavLayout(head templ.Component) {
 					activeMenuLink()
 				})
 			</script>
+			<script>
+				document.addEventListener('htmx:afterSettle', function() {
+					// Check if styles are already applied
+					const bodyStyles = window.getComputedStyle(document.body);
+					if (bodyStyles.display === 'block') {
+						// Styles are already applied, no need to reload
+						return;
+					}
+					// Force a reload of the stylesheet only if styles are missing
+					const stylesheet = document.querySelector('link[rel="stylesheet"]');
+					if (stylesheet) {
+						stylesheet.href = stylesheet.href + '?reload=' + Date.now();
+					}
+				});
+		</script>
 		</body>
 	</html>
 }

--- a/internal/views/pages/base.templ
+++ b/internal/views/pages/base.templ
@@ -237,17 +237,17 @@ templ SideNavLayout(head templ.Component) {
 			</script>
 			<script>
 				document.addEventListener('htmx:afterSettle', function() {
-					// Check if styles are already applied
-					const bodyStyles = window.getComputedStyle(document.body);
-					if (bodyStyles.display === 'block') {
-						// Styles are already applied, no need to reload
-						return;
-					}
-					// Force a reload of the stylesheet only if styles are missing
-					const stylesheet = document.querySelector('link[rel="stylesheet"]');
-					if (stylesheet) {
-						stylesheet.href = stylesheet.href + '?reload=' + Date.now();
-					}
+				// Check if styles are already applied
+				const bodyStyles = window.getComputedStyle(document.body);
+				if (bodyStyles.display === 'block') {
+					// Styles are already applied, no need to reload
+					return;
+				}
+				// Force a reload of the stylesheet only if styles are missing
+				const stylesheet = document.querySelector('link[rel="stylesheet"]');
+				if (stylesheet) {
+					stylesheet.href = stylesheet.href + '?reload=' + Date.now();
+				}
 				});
 		</script>
 		</body>

--- a/internal/views/pages/base.templ
+++ b/internal/views/pages/base.templ
@@ -249,7 +249,7 @@ templ SideNavLayout(head templ.Component) {
 					stylesheet.href = stylesheet.href + '?reload=' + Date.now();
 				}
 				});
-		</script>
+			</script>
 		</body>
 	</html>
 }


### PR DESCRIPTION
When a browser suspends an inactive tab and the user gets back to it, the styles are missing. I've observed this behavior with both Chrome and Firefox.

This fix automatically reloads the styles when they go missing.

p.s. Fan of the project. Keep up the great work! I had the same issue in the app I'm currently working on so I figure I contribute this fix  to the upstream.